### PR TITLE
Added support for API redirects

### DIFF
--- a/bindings/go/build.sh
+++ b/bindings/go/build.sh
@@ -20,7 +20,7 @@ EOC
 
 $root_dir/bin/swagger-codegen-cli generate \
     -c $build_json \
-    -i $api_url \
+    -i $openapi_url \
     -l go \
     -o $src_dir \
     $common_codegen_options

--- a/bindings/java/build.sh
+++ b/bindings/java/build.sh
@@ -15,7 +15,7 @@ cat > $build_json <<EOC
     "allowUnicodeIdentifiers": $allow_unicode_identifiers,
     "apiPackage": "io.cloudsmith.api.apis",
     "artifactId": "$project_dash",
-    "artifactUrl": "$api_url",
+    "artifactUrl": "$openapi_url",
     "artifactVersion": "$api_version",
     "artifactDescription": "$summary",
     "dateLibrary": "java8",
@@ -44,7 +44,7 @@ EOC
 
 $root_dir/bin/swagger-codegen-cli generate \
     -c $build_json \
-    -i $api_url \
+    -i $openapi_url \
     -l java \
     -o $src_dir \
     $common_codegen_options

--- a/bindings/python/build.sh
+++ b/bindings/python/build.sh
@@ -16,14 +16,14 @@ cat > $build_json <<EOC
     "packageName": "$project_underscore",
     "projectName": "$project_dash",
     "packageVersion": "$api_version",
-    "packageUrl": "$api_url",
+    "packageUrl": "$openapi_url",
     "sortParamsByRequiredFlag": $sort_params
 }
 EOC
 
 $root_dir/bin/swagger-codegen-cli generate \
     -c $build_json \
-    -i $api_url \
+    -i $openapi_url \
     -l python \
     -o $src_dir \
     $common_codegen_options

--- a/bindings/ruby/build.sh
+++ b/bindings/ruby/build.sh
@@ -17,7 +17,7 @@ cat > $build_json <<EOC
     "gemAuthor": "$author",
     "gemAuthorEmail": "$author_email",
     "gemLicense": "$license_spdx",
-    "gemHomepage": "$api_url",
+    "gemHomepage": "$openapi_url",
     "gemName": "$project_dash",
     "gemRequiredRubyVersion": ">= 1.9",
     "gemSummary": "$summary",
@@ -30,7 +30,7 @@ EOC
 
 $root_dir/bin/swagger-codegen-cli generate \
     -c $build_json \
-    -i $api_url \
+    -i $openapi_url \
     -l ruby \
     -o $src_dir \
     $common_codegen_options

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,6 +2,14 @@
 language=${1:-""}
 api_url=${2:-${api_url:-"https://api.cloudsmith.io/"}}
 api_version=$(curl -s "${api_url}status/check/basic/" | jq -r '.version')
+openapi_url="${api_url}?format=openapi"
+
+location=$(curl -s $openapi_url | grep Location | cut -d' ' -f2)
+[[ "$location" != "" ]] && {
+  openapi_scheme=$(echo $openapi_url | awk -F[/:] '{print $1}')
+  openapi_hostname=$(echo $openapi_url | awk -F[/:] '{print $4}')
+  openapi_url="${openapi_scheme}://${openapi_hostname}${location}"
+}
 
 # Bindings attributes/config
 allow_unicode_identifiers="true"


### PR DESCRIPTION
# What Changed?

The new API endpoint has a slightly different location for the OpenAPI specification, and the old one will now exist there as a permanent redirect. The Swagger code generator, by default, doesn't handle this, so is a workaround to handle the redirect for it.