### PR TITLE
fix(swagger-codegen): Python client produces invalid regex when using swagger-codegen.

### DIFF
--- a/bindings/python/templates/model.mustache
+++ b/bindings/python/templates/model.mustache
@@ -158,7 +158,7 @@ class {{classname}}(object):
 {{/minimum}}
 {{#pattern}}
         if (self._configuration.client_side_validation and
-                {{name}} is not None and not re.search(r'{{{vendorExtensions.x-regex}}}', {{name}}{{#vendorExtensions.x-modifiers}}{{#-first}}, flags={{/-first}}re.{{.}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}})):  # noqa: E501
+                {{name}} is not None and not re.search('{{{vendorExtensions.x-regex}}}', {{name}}{{#vendorExtensions.x-modifiers}}{{#-first}}, flags={{/-first}}re.{{.}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}})):  # noqa: E501
             raise ValueError(r"Invalid value for `{{name}}`, must be a follow pattern or equal to `{{{pattern}}}`")  # noqa: E501
 {{/pattern}}
 {{#maxItems}}


### PR DESCRIPTION
- Updated model pattern template to use regular string instead of raw string. 
- This is old swagger-codegen behaviour. Seems it's caused a few issues for people including me when testing out the newly generated Python binding with the CLI.
- https://github.com/swagger-api/swagger-codegen/issues/9538