### PR TITLE
revert: use README.md for long_description

### DIFF
--- a/bindings/python/src/setup.py
+++ b/bindings/python/src/setup.py
@@ -11,7 +11,6 @@
 """
 
 
-import os
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "cloudsmith-api"
@@ -29,11 +28,6 @@ REQUIRES = [
     "six>=1.10",
     "urllib3>=1.23"
 ]
-
-here = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-with open(os.path.join(here, "README.md")) as f:
-    long_description = f.read()
-
     
 
 setup(
@@ -46,6 +40,7 @@ setup(
     install_requires=REQUIRES,
     packages=find_packages(),
     include_package_data=True,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description="""\
+    The API to the Cloudsmith Service  # noqa: E501
+    """
 )


### PR DESCRIPTION
revert #45 

Didn't realise that swagger-codegen-cli actually overwrites this file on build, so it's back to the drawing board...