### PR TITLE
Update PyPI authentication method.

### DIFF
--- a/bindings/python/deploy.sh
+++ b/bindings/python/deploy.sh
@@ -25,7 +25,7 @@ upload_to_pypi() {
 
   if [[ "$CI" == "true" ]]
   then
-    twine upload -u csm-api-bot -p "$PYPI_PASSWORD" --skip-existing --non-interactive "$distribution_filepath"
+    twine upload -u __token__ -p "$PYPI_PASSWORD" --skip-existing --non-interactive "$distribution_filepath"
   else
     twine upload --skip-existing --non-interactive "$distribution_filepath"
   fi


### PR DESCRIPTION
Username/Password authentication no longer supported. 

```
HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Username/Password authentication is no longer supported. Migrate to API
         Tokens or Trusted Publishers instead.
```