### PR TITLE
fix: autofix invalid escape sequences with ruff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,27 @@ jobs:
       - prepare_deploy_environment
       - deploy_bindings:
           language: <<parameters.language>>
+  pre_commit:
+    description: "Run pre-commit hooks"
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - run:
+          name: "Install dependencies"
+          command: |
+            python3 -m pip install --upgrade pip
+            pip install pre-commit
+      - run:
+          name: "Run pre-commit"
+          command: pre-commit run --all-files
+
 
 workflows:
   version: 2
   test_and_deploy:
     jobs:
+      - pre_commit
       - test:
           name: "Test Java"
           language: java

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+pre-commit install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.9
+  hooks:
+    - id: ruff
+      args: [ --fix ]

--- a/bindings/python/src/cloudsmith_api/models/composer_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/composer_upstream.py
@@ -466,7 +466,7 @@ class ComposerUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/composer_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/composer_upstream_request.py
@@ -390,7 +390,7 @@ class ComposerUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/composer_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/composer_upstream_request_patch.py
@@ -390,7 +390,7 @@ class ComposerUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/cran_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/cran_upstream.py
@@ -466,7 +466,7 @@ class CranUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/cran_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/cran_upstream_request.py
@@ -390,7 +390,7 @@ class CranUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/cran_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/cran_upstream_request_patch.py
@@ -390,7 +390,7 @@ class CranUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/dart_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/dart_upstream.py
@@ -466,7 +466,7 @@ class DartUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/dart_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/dart_upstream_request.py
@@ -390,7 +390,7 @@ class DartUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/dart_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/dart_upstream_request_patch.py
@@ -390,7 +390,7 @@ class DartUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/deb_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/deb_upstream.py
@@ -661,7 +661,7 @@ class DebUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/deb_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/deb_upstream_request.py
@@ -580,7 +580,7 @@ class DebUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/deb_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/deb_upstream_request_patch.py
@@ -579,7 +579,7 @@ class DebUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/docker_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/docker_upstream.py
@@ -466,7 +466,7 @@ class DockerUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/docker_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/docker_upstream_request.py
@@ -390,7 +390,7 @@ class DockerUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/docker_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/docker_upstream_request_patch.py
@@ -390,7 +390,7 @@ class DockerUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/helm_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/helm_upstream.py
@@ -466,7 +466,7 @@ class HelmUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/helm_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/helm_upstream_request.py
@@ -390,7 +390,7 @@ class HelmUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/helm_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/helm_upstream_request_patch.py
@@ -390,7 +390,7 @@ class HelmUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/hex_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/hex_upstream.py
@@ -466,7 +466,7 @@ class HexUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/hex_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/hex_upstream_request.py
@@ -390,7 +390,7 @@ class HexUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/hex_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/hex_upstream_request_patch.py
@@ -390,7 +390,7 @@ class HexUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/maven_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/maven_upstream.py
@@ -565,7 +565,7 @@ class MavenUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/maven_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/maven_upstream_request.py
@@ -484,7 +484,7 @@ class MavenUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/maven_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/maven_upstream_request_patch.py
@@ -484,7 +484,7 @@ class MavenUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/npm_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/npm_upstream.py
@@ -466,7 +466,7 @@ class NpmUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/npm_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/npm_upstream_request.py
@@ -390,7 +390,7 @@ class NpmUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/npm_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/npm_upstream_request_patch.py
@@ -390,7 +390,7 @@ class NpmUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/nuget_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/nuget_upstream.py
@@ -466,7 +466,7 @@ class NugetUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/nuget_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/nuget_upstream_request.py
@@ -390,7 +390,7 @@ class NugetUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/nuget_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/nuget_upstream_request_patch.py
@@ -390,7 +390,7 @@ class NugetUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/python_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/python_upstream.py
@@ -466,7 +466,7 @@ class PythonUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/python_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/python_upstream_request.py
@@ -390,7 +390,7 @@ class PythonUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/python_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/python_upstream_request_patch.py
@@ -390,7 +390,7 @@ class PythonUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/repository.py
+++ b/bindings/python/src/cloudsmith_api/models/repository.py
@@ -949,7 +949,7 @@ class Repository(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/repository_create.py
+++ b/bindings/python/src/cloudsmith_api/models/repository_create.py
@@ -949,7 +949,7 @@ class RepositoryCreate(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/repository_create_request.py
+++ b/bindings/python/src/cloudsmith_api/models/repository_create_request.py
@@ -672,7 +672,7 @@ class RepositoryCreateRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/repository_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/repository_request_patch.py
@@ -666,7 +666,7 @@ class RepositoryRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/rpm_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/rpm_upstream.py
@@ -622,7 +622,7 @@ class RpmUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/rpm_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/rpm_upstream_request.py
@@ -541,7 +541,7 @@ class RpmUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/rpm_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/rpm_upstream_request_patch.py
@@ -540,7 +540,7 @@ class RpmUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/ruby_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/ruby_upstream.py
@@ -466,7 +466,7 @@ class RubyUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/ruby_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/ruby_upstream_request.py
@@ -390,7 +390,7 @@ class RubyUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/ruby_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/ruby_upstream_request_patch.py
@@ -390,7 +390,7 @@ class RubyUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/swift_upstream.py
+++ b/bindings/python/src/cloudsmith_api/models/swift_upstream.py
@@ -466,7 +466,7 @@ class SwiftUpstream(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/swift_upstream_request.py
+++ b/bindings/python/src/cloudsmith_api/models/swift_upstream_request.py
@@ -390,7 +390,7 @@ class SwiftUpstreamRequest(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/bindings/python/src/cloudsmith_api/models/swift_upstream_request_patch.py
+++ b/bindings/python/src/cloudsmith_api/models/swift_upstream_request_patch.py
@@ -390,7 +390,7 @@ class SwiftUpstreamRequestPatch(object):
                 name is not None and len(name) < 1):
             raise ValueError("Invalid value for `name`, length must be greater than or equal to `1`")  # noqa: E501
         if (self._configuration.client_side_validation and
-                name is not None and not re.search('^\\w[\\w \\-\'\\.\/()]+$', name)):  # noqa: E501
+                name is not None and not re.search('^\\w[\\w \\-\'\\.\\/()]+$', name)):  # noqa: E501
             raise ValueError(r"Invalid value for `name`, must be a follow pattern or equal to `/^\\w[\\w \\-'\\.\/()]+$/`")  # noqa: E501
 
         self._name = name

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+target-version = "py38"
+
+[lint]
+select = [
+    "W605",  # invalid-escape-sequence
+]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]


### PR DESCRIPTION
As reported in https://github.com/cloudsmith-io/cloudsmith-cli/issues/167

The generated Python bindings fire a tonne of invalid escape sequence warnings in modern interpreters.

This PR uses ruff via pre-commit to autofix those.

Verified that this fails in CirecleCI when pre-commit hooks haven't been run:

![image](https://github.com/user-attachments/assets/5f1d912a-09df-4c67-889d-214c9dbb4d86)
