### PR TITLE
fix(no-ticket): rename to confirm to PEP 625

### DIFF
--- a/bindings/python/src/setup.py
+++ b/bindings/python/src/setup.py
@@ -13,7 +13,7 @@
 
 from setuptools import setup, find_packages  # noqa: H301
 
-NAME = "cloudsmith-api"
+NAME = "cloudsmith_api"
 VERSION = "2.0.18"
 # To install the library, run the following
 #


### PR DESCRIPTION
Renaming to confirm with [PEP 625](https://peps.python.org/pep-0625/) cloudsmith-api vs cloudsmith_api