### PR TITLE
fix: update-bindings.sh — converge pre-commit before commit, don't push aborted commits

### DIFF
--- a/scripts/update-bindings.sh
+++ b/scripts/update-bindings.sh
@@ -144,6 +144,30 @@ generate_bindings() {
     fi
 }
 
+run_precommit_to_convergence() {
+    if ! command -v pre-commit &> /dev/null; then
+        log_warning "pre-commit not found; skipping explicit hook run (the git commit hook, if installed, will still run)"
+        return 0
+    fi
+
+    log_info "Running pre-commit hooks to convergence before committing..."
+
+    local attempt=1
+    local max_attempts=5
+    while ! pre-commit run --all-files; do
+        git add .
+        if [ "$attempt" -ge "$max_attempts" ]; then
+            log_error "pre-commit hooks did not converge after $max_attempts attempts; aborting before commit"
+            exit 1
+        fi
+        attempt=$((attempt + 1))
+        log_warning "pre-commit modified files; re-staging and retrying (attempt $attempt)..."
+    done
+
+    git add .
+    log_success "pre-commit hooks passed"
+}
+
 create_and_push_branch() {
     local version="$1"
     local api_version="$2"
@@ -180,15 +204,20 @@ create_and_push_branch() {
         return 1
     fi
     
-    git commit -m "Update API bindings to version $version
+    run_precommit_to_convergence
+
+    if ! git commit -m "Update API bindings to version $version
 
 Binding version: $version
 CloudSmith API version: $api_version
 
 - Updated package_version in scripts/common.sh
 - Regenerated bindings for Python, Ruby, and Java
-- Ready for automated deployment via CircleCI"
-    
+- Ready for automated deployment via CircleCI"; then
+        log_error "git commit failed (a pre-commit hook may have aborted it). Not pushing branch $branch_name."
+        exit 1
+    fi
+
     log_info "Pushing branch to origin..."
     if ! git push origin "$branch_name"; then
         log_warning "Normal push failed, trying force push..."


### PR DESCRIPTION
## Problem

`scripts/update-bindings.sh` runs `git commit` with the `ruff` pre-commit hook active. When ruff auto-fixes files (e.g. the W605 invalid-escape-sequence warnings that always appear in freshly-generated Python bindings), it **modifies the working tree and aborts the commit**. The script doesn't check the commit's exit status, so it proceeds to `git push` regardless — leaving the remote branch pointing at the **same commit as `master`** with all the regenerated changes sitting uncommitted in the working tree.

The result is an "empty" update branch that requires a manual rescue (re-stage, re-run pre-commit, fix, commit, push) before a PR can be opened. This was hit again on the v2.0.28 update (#93).

## Fix

- **`run_precommit_to_convergence()`** — runs `pre-commit run --all-files`, re-staging and retrying (up to 5 attempts) until the hooks pass with no further modifications. This captures ruff's auto-fixes *before* the commit, so the commit hook no longer aborts.
- **Guard `git commit`** — if the commit still fails for any reason, log and `exit 1` instead of falling through to `git push`. The branch is never pushed without its commit.

No behavioural change on the happy path (clean tree → hooks pass first try → commit → push).

## Verification

- `bash -n scripts/update-bindings.sh` — passes
- `shellcheck` — no new findings (pre-existing SC2034/SC2155 warnings untouched)
- Convergence loop unit-tested in isolation with a stubbed `pre-commit`:
  - hook that auto-fixes twice then passes → converges, exit 0
  - hook that never passes → aborts after 5 attempts with exit 1 (no fall-through to commit/push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)