### PR TITLE
fix: unbreak the scheduled binding-update workflow (exit 127)

### DIFF
--- a/bindings/java/build.sh
+++ b/bindings/java/build.sh
@@ -45,7 +45,7 @@ cat > $build_json <<EOC
 }
 EOC
 
-docker container run --rm -v $self_dir:/local "${swagger_codegen_cli_image:?}" generate \
+docker container run --rm --user "${codegen_run_user:?}" -v $self_dir:/local "${swagger_codegen_cli_image:?}" generate \
     --type-mappings Integer=java.math.BigInteger \
     -c /local/src/build.json \
     -i $openapi_url \

--- a/bindings/python/build.sh
+++ b/bindings/python/build.sh
@@ -24,7 +24,7 @@ cat > $build_json <<EOC
 }
 EOC
 
-docker container run --rm -v $self_dir:/local "${swagger_codegen_cli_image:?}" generate \
+docker container run --rm --user "${codegen_run_user:?}" -v $self_dir:/local "${swagger_codegen_cli_image:?}" generate \
     -c /local/src/build.json \
     -i $openapi_url \
     -l python \

--- a/bindings/ruby/build.sh
+++ b/bindings/ruby/build.sh
@@ -31,7 +31,7 @@ cat > $build_json <<EOC
 }
 EOC
 
-docker container run --rm -v $self_dir:/local "${swagger_codegen_cli_image:?}" generate \
+docker container run --rm --user "${codegen_run_user:?}" -v $self_dir:/local "${swagger_codegen_cli_image:?}" generate \
     -c /local/src/build.json \
     -i $openapi_url \
     -l ruby \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,13 +36,13 @@ build_language() {
   $root_dir/bindings/$language/build.sh
 }
 
-test -z "$language" && {
+if test -z "$language"; then
   for I in $root_dir/bindings/*; do
     build_language $(basename $I)
   done
-} || {
+else
   build_language $language
-}
+fi
 
 echo "Applying ruff autofixes to generated sources ..."
 uvx ruff check --fix "$root_dir"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -34,6 +34,12 @@ summary="Cloudsmith API"
 
 common_codegen_options="--git-user-id $git_user_id --git-repo-id $git_repo_id"
 
+# Codegen writes into a bind-mounted directory. On Linux the container's root
+# user owns the result, which blocks the post-generation fixups (Ruby
+# re-escaping, ruff autofixes) from rewriting those files, so run as the
+# invoking user instead.
+codegen_run_user="$(id -u):$(id -g)"
+
 function die {
   echo "$@"
   exit 1


### PR DESCRIPTION
The scheduled **Update API bindings** workflow has been failing at the *Generate bindings* step with `exit code 127` ([run 30521202208](https://github.com/cloudsmith-io/cloudsmith-api/actions/runs/30521202208/job/90801772683)).

Two separate defects combined to produce it.

### 1. Codegen output was root-owned (the actual failure)

`docker container run` writes into the bind-mounted `bindings/<lang>/src` directory as the container's root user, so on Linux the generated files end up owned by root.

`scripts/fix-ruby-escaping.sh` uses `ruby -i` (in-place edit), which must **unlink the original file** and therefore needs write permission on the *containing directory*, not just the file. That unlink failed:

```
-e:1: warning: Can't remove .../models/helm_upstream.rb: Permission denied, skipping file
ruby: .../models/helm_upstream.rb:308: syntax errors found (SyntaxError)
```

So the apostrophe fix was silently skipped and the following `ruby -c` reported the very syntax error it exists to prevent. The `uvx ruff check --fix` pass at the end of `scripts/build.sh` would have hit the same wall (it rewrote 67 files in a local run).

This never reproduced locally because macOS bind mounts map container-root writes back to the host user — it only bites on Linux runners, which is why the first scheduled run surfaced it.

**Fix:** run the codegen container as the invoking user via `--user "$(id -u):$(id -g)"`, defined once as `codegen_run_user` in `scripts/common.sh`.

### 2. The real error was then masked as exit 127

`scripts/build.sh` dispatched languages with the classic `A && B || C` pitfall:

```bash
test -z "$language" && {
  for I in $root_dir/bindings/*; do build_language $(basename $I); done
} || {
  build_language $language
}
```

When a per-language build failed, the `for` loop returned non-zero, so the `||` branch ran **with an empty `$language`** — producing the confusing tail of the log:

```
./scripts/build.sh: line 36: .../bindings//build.sh: No such file or directory
Building  bindings ...
```

and replacing the genuine exit status with `127`.

**Fix:** a plain `if`/`else`, so a failing language build propagates its own status.

### Verification

- Reproduced defect 2 in isolation and confirmed the fix makes the real exit status propagate instead of the bogus empty-language branch.
- Reproduced defect 1's mechanism with a non-writable models directory — byte-identical `Can't remove ... Permission denied` warning followed by the `ruby -c` syntax error; passes once the directory is user-writable.
- Confirmed `swaggerapi/swagger-codegen-cli:v2.4.50` generates correctly under `--user`.
- `mise run build` now completes end-to-end (exit 0), Ruby escaping applied to all 20 `*_upstream.rb` models and verified with `ruby -c`, ruff autofixes applied.
- Regenerating produced a **zero diff** against the committed Ruby bindings, confirming the escaping fix is idempotent. (The only drift was `PackageFileUploadRequest` in java/python from genuine API movement since v1.1285.0; reverted here so this PR stays scoped to the CI fix — the next scheduled run will pick it up.)
- `prek run --all-files`: ruff and zizmor both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)