### PR TITLE
add signing to workflow

### DIFF
--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -90,6 +90,7 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          sign-commits: true
           branch: automated/update-bindings-v${{ steps.versions.outputs.new_version }}
           base: master
           title: "feat: update bindings to v${{ steps.versions.outputs.new_version }} (API v${{ steps.versions.outputs.api_version }})"


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for updating bindings. The change ensures that commits created by the workflow are signed, improving commit authenticity and traceability.

* Workflow improvement:
  * [`.github/workflows/update-bindings.yml`](diffhunk://#diff-177ffb7a8f2afa3f4f7cb8afe7017d18f76111292ad70b75b5eb98b80510d988R93): Added `sign-commits: true` to the `create-pull-request` step to enable signed commits.